### PR TITLE
README.md: reflect release of tailwind 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <h3 align="center">Hugo TailwindCSS Starter</h3>
 
   <p align="center">
-    A starter project for Hugo and TailwindCSS v4.0
+    A starter project for Hugo and TailwindCSS v4.1
     <br />
     Ready to deploy in Vercel 🚀
     <br />
@@ -34,7 +34,7 @@
 
 ## Welcome
 
-This starter project integrates **Hugo** with **TailwindCSS v4.0** and is ready for deployment on **Vercel**.
+This starter project integrates **Hugo** with **TailwindCSS v4.1** and is ready for deployment on **Vercel**.
 
 ### Built With
 
@@ -44,7 +44,7 @@ This starter project integrates **Hugo** with **TailwindCSS v4.0** and is ready 
 
 ### Features
 
-- Integration of Hugo and TailwindCSS v4.0
+- Integration of Hugo and TailwindCSS v4.1
 - Easy deployment with Vercel
 - Starter templates for rapid development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-tailwindcss-starter",
-  "description": "Starter project for Hugo and TailwindCSS v4.0, ready to deploy in Vercel!",
+  "description": "Starter project for Hugo and TailwindCSS v4.1, ready to deploy in Vercel!",
   "version": "2.0.0",
   "license": "MIT",
   "author": "Odhy Pradhana (odhyp.com)",


### PR DESCRIPTION
Tailwind is at version 4.1 now. This PR reflect this version change.

This should be reflected in the `ABOUT` section in the right sidebar of this repo, too:
![grafik](https://github.com/user-attachments/assets/86b370f8-e9fc-450a-b47d-7a0d5845805d)
